### PR TITLE
use the color's display/presentation value instead of its named value

### DIFF
--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -67,7 +67,7 @@ xml.Orders(pages: (@shipments.total_count/50.0).ceil) {
                 variant.option_values.each do |value|
                   xml.Option {
                     xml.Name  value.option_type.presentation
-                    xml.Value value.name
+                    xml.Value value.option_type.presentation == "Color" ? value.presentation : value.name
                   }
                 end
               }


### PR DESCRIPTION
use named value for every other option
